### PR TITLE
Standardize kernels

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -10,6 +10,7 @@ dependencies:
   - torchvision
   - scikit-learn
   - jupyter-book
+  - jupyterlab
   - pre-commit
   - pip
   - pip:

--- a/notebooks/Neural-Network-Advection-FwdEuler.ipynb
+++ b/notebooks/Neural-Network-Advection-FwdEuler.ipynb
@@ -1212,9 +1212,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1891,9 +1889,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2277,9 +2273,7 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -3333,9 +3327,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ML",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "ml"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -3347,7 +3341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/Neural-Network-Advection.ipynb
+++ b/notebooks/Neural-Network-Advection.ipynb
@@ -1224,9 +1224,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2162,9 +2160,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2472,9 +2468,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -3621,9 +3615,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ML",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "ml"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -3635,7 +3629,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The advection notebooks used a custom kernel called "ml". This replaces it with the standard "python3" kernel so they will build automatically.