### PR TITLE
Changes the timeout from 30 secs to 2 mins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ logo: newlogo.png
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: cache
+  timeout: 120
 
 parse:
   myst_enable_extensions:


### PR DESCRIPTION
Changing the timeout for notebook cells from 30 seconds to 2 minutes should avoid timeouts in the actions build.