### PR TITLE
Fixing header levels and bulleting in Neural_network_for_Lorenz96.ipynb

### DIFF
--- a/notebooks/Neural_network_for_Lorenz96.ipynb
+++ b/notebooks/Neural_network_for_Lorenz96.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create GCM classes with and without neural network parameterization"
+    "## Create GCM classes with and without neural network parameterization"
    ]
   },
   {
@@ -193,7 +193,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Getting training data (input output pairs): "
+    "### Getting training data (input output pairs): "
    ]
   },
   {
@@ -211,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Split to train and test (validation) data:"
+    "### Split to train and test (validation) data:"
    ]
   },
   {
@@ -316,9 +316,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Neural networks can have many different structures. \n",
-    "- #### Here we will consider fully connected networks\n",
-    "- #### To undersand fully connected networks, we only need to understand Linear regression (and gradient descent).\n",
+    "### Neural networks can have many different structures. \n",
+    "- Here we will consider fully connected networks\n",
+    "- To undersand fully connected networks, we only need to understand Linear regression (and gradient descent).\n",
     "\n"
    ]
   },
@@ -459,10 +459,14 @@
     "it’s crucial you choose the correct learning rate ($LR$) as otherwise your network will either fail to train, or take much longer to converge. [Here](https://towardsdatascience.com/stochastic-gradient-descent-with-momentum-a84097641a5d) you can read more about the momentum term in SGD.\n",
     "\n",
     "### The  effective value of the gradient (V) at step t in SGD with momentum ($\\beta$):\n",
-    "### $V_t = \\beta V_{t-1} + (1-\\beta) \\nabla_w L(W,X,y)$\n",
+    "\\begin{equation}\n",
+    "V_t = \\beta V_{t-1} + (1-\\beta) \\nabla_w L(W,X,y)\n",
+    "\\end{equation}\n",
     "\n",
     "### and the updates to the weights will be:\n",
-    "### $w^{new} = w^{old} - LR * V_t$"
+    "\\begin{equation}\n",
+    "w^{new} = w^{old} - LR * V_t\n",
+    "\\end{equation}"
    ]
   },
   {
@@ -473,7 +477,7 @@
     "\n",
     "The choice of which optimizer we choose might be very important. It will determine how fast the network will be able to learn. Adam is a very popular choice (read more [here](https://towardsdatascience.com/adam-latest-trends-in-deep-learning-optimization-6be9a291375c) about Adam, and [here](https://ruder.io/optimizing-gradient-descent/index.html#adam) about many types of different optimizers). \n",
     "\n",
-    "- #### Adam is an adaptive learning rate method, which means, it computes individual learning rates for different parameters.\n"
+    "- Adam is an adaptive learning rate method, which means, it computes individual learning rates for different parameters.\n"
    ]
   },
   {
@@ -728,7 +732,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### If layers contain only matrix multiplications, everything would be linear. \n",
+    "### If layers contain only matrix multiplications, everything would be linear. \n",
     "- e.g., 2 layers of weight matrices  A and B (x is the input) would give $A(Bx)$, which is linear (in x)\n",
     "- Therefore, we need to introduce some non-linearity (activation function). \n",
     "\n",
@@ -909,7 +913,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Regularization and overfitting"
+    "## Regularization and overfitting"
    ]
   },
   {
@@ -935,10 +939,12 @@
     "All ML algorithms has some form of regularization. \n",
     "\n",
     "### Useful ways to think of regularization:\n",
-    "- #### Putting constraints on the model\n",
+    "- Putting constraints on the model\n",
     "Aiming to have a better generalizability (avoid modeling the noise or \"remembering\" training data). \n",
-    "- #### Adding a term to the loss function so that: Loss = Training Loss + Regularization\n",
-    "Put a penalty for making the model more complex. \n",
+    "- Adding a term to the loss function so that:  \n",
+    "> Loss = Training Loss + Regularization\n",
+    "\n",
+    "puts a penalty for making the model more complex. \n",
     "\n",
     "Very braodly speaking (just to gain intuition) - if we want to reduce the training loss (reduce bias) we should try using a more complex model (if we have enough data) and if we want to reduce overfitting (reduce variace) we should simplify or constraint the model we use (increase regularization). "
    ]
@@ -1093,7 +1099,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Visuzlization of the loss function"
+    "## Visuzlization of the loss function"
    ]
   },
   {
@@ -1195,7 +1201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## I won't talk about but I recommend reading:"
+    "# I won't talk about but I recommend reading:"
    ]
   },
   {


### PR DESCRIPTION
Replaces #56 partially addressing #38 

- The markdown header levels are ordered for consistency.
- Minor bullet/equation changes
