### PR TITLE
fixes #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ To check the status of the cache, run
 jcache cache list -p _build/.jupyter_cache
 ```
 
-To clear the cache, run
+To remove cached notebooks, run
 
 ```
-jcache cache clear -p _build/.jupyter_cache
+jcache cache remove -p _build/.jupyter_cache
 ```
 
 ## Contributing

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,3 +15,4 @@ dependencies:
   - jupyterlab
   - pre-commit
   - ffmpeg
+  - tabulate


### PR DESCRIPTION
## Changes
- Tabulate module added to environment.yaml
- Updated README.MD to use ```remove``` instead of ```clear```
  - ```clear``` is no longer supported
 ```
(L96M2lines) shubham@Shubhams-MBP L96_demo % jcache cache clear -p _build/.jupyter_cache
Usage: jcache cache [OPTIONS] COMMAND [ARGS]...
Try 'jcache cache -h' for help.

Error: No such command 'clear'.
```