### PR TITLE
Possible fix for title v2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Book settings
 # Learn more at https://jupyterbook.org/customize/config.html
 
+# this title does not seem to work, refer to sphinx.config.html_theme_options.logo.text
 title: Learning Machine Learning with Lorenz-96
 author: The M<sup>2</sup>LInES Community
 logo: newlogo.png
@@ -36,6 +37,10 @@ sphinx:
   config:
     bibtex_reference_style: author_year
     nb_merge_streams: true
+    html_theme_options:
+      # title of the notebook
+      logo:
+        text: "Learning Machine Learning with Lorenz-96"
 
 # Information about where the book exists on the web
 repository:


### PR DESCRIPTION
- Issue is documented well here - https://github.com/executablebooks/jupyter-book/issues/2013
- Users seem to have found a workaround, but currently looks like a bug on Jupyterbook side (our code and deployments are correct!)
 
## Known issues:
- the search bar below the title as seen in https://github.com/m2lines/L96_demo/issues/106#issuecomment-1569481926 is still missing
- an example - https://nocomplexity.com/documents/securityarchitecture/introduction.html