### PR TITLE
closing remarks force rebuild page

### DIFF
--- a/notebooks/closing_remarks.ipynb
+++ b/notebooks/closing_remarks.ipynb
@@ -16,14 +16,6 @@
     "\n",
     "These novel techniques and data-driven models are now making their way into global climate models {cite}`zhang2023implementation`, illustrating the importance of bringing climate physics, scientific computing, and modern machine learning techniques together."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ee52d6aa-a3bb-4adc-ba27-226bd9c638c6",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Currently the remarks page are not reflecting the latest changes. This PR has minor text changes to force GitHub pages to rebuild and deploy the website again. Merge this only if page still looks like in the screenshot below (can be closed otherwise)

<img width="1512" alt="Screenshot 2023-10-14 at 11 52 25 AM" src="https://github.com/m2lines/L96_demo/assets/32878682/192d3705-e2b4-47a2-ae5a-3471f6562300">
